### PR TITLE
Add Abaqus Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ A curated list of awesome CAE frameworks, libraries and software.
 * [Simright Converter](https://www.simright.com/apps/simright-converter) - Simright Converter is a web-based tool for converting CAE models between different formats. 
 * [abaqus_scripts](https://github.com/rodrigo1392) - Python scripts to automate the boring stuff in everyday use of Simulia Abaqus, from opening the GUI to controlling parametric analysis.
 * [abqpy](https://github.com/haiiliin/abqpy) - Type hints for Abaqus/Python scripting.
+* [Abaqus Agent Skills](https://github.com/1348109517/abaqus-agent-skills) - Reusable workflow skills and a dependency-free static contract audit demo for AI-assisted Abaqus automation.
 
 ---------
 # Editors


### PR DESCRIPTION
Adds Abaqus Agent Skills to the Tools section. The Apache-2.0 project provides reusable workflow guidance plus a dependency-free synthetic static-contract audit demo for AI-assisted Abaqus automation. It is independently maintained and does not bundle Abaqus or claim solver/engineering validation.